### PR TITLE
Feat: Add proxy arg to client creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Disable chrono default features by @silverpill ([#87](https://github.com/monero-ecosystem/monero-rpc-rs/pull/87))
 
+### Changed
+
+- Add a new initialization of an RpcClient with ::with(...) to include a proxy argument. This allows the usage of e.g. a Tor socks proxy. This argument has to be a string pointing to the the address of the proxy and its protocol prefix, .e.g. "socks5://127.0.0.1:9050" for using a socks5 proxy.
+
 ## [0.2.0] - 2022-07-29
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ hex = "0.4"
 http = "0.2"
 jsonrpc-core = "18"
 monero = { version = "0.18", features = ["serde"] }
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", features = ["json", "socks"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,14 @@
 //! let daemon = client.daemon();
 //! let regtest_daemon = daemon.regtest();
 //! ```
+//!
+//! The client can be initialized with a proxy, for example a socks5 proxy to enable Tor:
+//!
+//! ```rust
+//! use monero_rpc::RpcClient;
+//!
+//! let client = RpcClient::with("http://node.monerooutreach.org:18081".to_string(), "socks5://127.0.0.1:9050".to_string());
+//! ```
 
 #![forbid(unsafe_code)]
 
@@ -197,6 +205,19 @@ impl RpcClient {
         Self {
             inner: CallerWrapper(Arc::new(RemoteCaller {
                 http_client: reqwest::ClientBuilder::new().build().unwrap(),
+                addr,
+            })),
+        }
+    }
+
+    /// Create a new generic RPC client with a proxy
+    pub fn with(addr: String, proxy_address: String) -> Self {
+        Self {
+            inner: CallerWrapper(Arc::new(RemoteCaller {
+                http_client: reqwest::Client::builder()
+                    .proxy(reqwest::Proxy::all(proxy_address).unwrap())
+                    .build()
+                    .unwrap(),
                 addr,
             })),
         }


### PR DESCRIPTION
Allowing the user to specify a proxy, is useful to allow him to connect to a server through tor, analyze the traffic, or go through any number of anonymising services.