### PR TITLE
RPC authentication

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,29 +12,13 @@ jobs:
       matrix:
         monero: [ 0.17.3.0, 0.17.3.2, 0.18.0.0 ]
 
-    services:
-      monerod:
-        image: ghcr.io/farcaster-project/containers/monerod:${{ matrix.monero }}
-        env:
-          NETWORK: regtest
-          MONEROD_RPC_PORT: 18081
-          MONEROD_ZMQ_PORT: 18082
-          OFFLINE: --offline
-          DIFFICULTY: 1
-        ports:
-        - 18081:18081
-        - 18082:18082
-      monero-wallet-rpc:
-        image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:${{ matrix.monero }}
-        env:
-          MONERO_DAEMON_ADDRESS: monerod:18081
-          MONERO_DAEMON_HOST: monerod:18081
-          WALLET_RPC_PORT: 18083
-        ports:
-        - 18083:18083
-
     steps:
       - uses: actions/checkout@v3
+
+      - name: Spin up containers
+        run: docker-compose -f tests/docker-compose.yml up -d
+        env:
+          MONERO_VERSION: ${{ matrix.monero }}
 
       - name: Install Rust Stable
         uses: actions-rs/toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ description = "RPC client for Monero daemon and wallet"
 [dependencies]
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
+diqwest = "1.1"
 fixed-hash = "0.7"
 hex = "0.4"
 http = "0.2"
@@ -23,7 +24,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"
 uuid = { version = "1.1", features = ["v4"] }
-diqwest = "1.1"
 
 [dev-dependencies]
 # Async

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ description = "RPC client for Monero daemon and wallet"
 [dependencies]
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
-diqwest = "1.1"
-fixed-hash = "0.7"
+diqwest = { version = "1.1", optional = true }
+fixed-hash = "0.8"
 hex = "0.4"
 http = "0.2"
 jsonrpc-core = "18"
@@ -31,3 +31,6 @@ rand = "0.8.4"
 rustc-hex = "2.1"
 serde_test = "1.0"
 tokio = { version = "1.12.0", features = ["full"] }
+
+[features]
+rpc_authentication = ["dep:diqwest"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"
 uuid = { version = "1.1", features = ["v4"] }
+diqwest = "1.1"
 
 [dev-dependencies]
 # Async

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,8 +61,8 @@ use std::{
 use tracing::*;
 use uuid::Uuid;
 
-use diqwest::WithDigestAuth;
 use crate::RpcAuthentication::Credentials;
+use diqwest::WithDigestAuth;
 
 enum RpcParams {
     Array(Box<dyn Iterator<Item = Value> + Send + 'static>),
@@ -72,7 +72,7 @@ enum RpcParams {
 
 #[derive(Clone, Debug)]
 pub enum RpcAuthentication {
-    Credentials{username: String, password: String},
+    Credentials { username: String, password: String },
     None,
 }
 
@@ -106,7 +106,7 @@ impl From<RpcParams> for Params {
 struct RemoteCaller {
     http_client: reqwest::Client,
     addr: String,
-    rpc_auth: RpcAuthentication
+    rpc_auth: RpcAuthentication,
 }
 
 impl RemoteCaller {
@@ -127,20 +127,15 @@ impl RemoteCaller {
 
         trace!("Sending JSON-RPC method call: {:?}", method_call);
 
-        let req = client
-            .post(&uri)
-            .json(&method_call);
+        let req = client.post(&uri).json(&method_call);
 
-        let rsp = if let Credentials{username, password} = &self.rpc_auth {
+        let rsp = if let Credentials { username, password } = &self.rpc_auth {
             req.send_with_digest_auth(username, password)
                 .await?
                 .json::<response::Output>()
                 .await?
-        } else{
-            req.send()
-                .await?
-                .json::<response::Output>()
-                .await?
+        } else {
+            req.send().await?.json::<response::Output>().await?
         };
 
         trace!("Received JSON-RPC response: {:?}", rsp);
@@ -163,20 +158,15 @@ impl RemoteCaller {
             json_params
         );
 
-        let req = client
-            .post(uri)
-            .json(&json_params);
+        let req = client.post(uri).json(&json_params);
 
-        let rsp = if let Credentials{username, password} = &self.rpc_auth {
+        let rsp = if let Credentials { username, password } = &self.rpc_auth {
             req.send_with_digest_auth(username, password)
                 .await?
                 .json::<T>()
                 .await?
-        } else{
-            req.send()
-                .await?
-                .json::<T>()
-                .await?
+        } else {
+            req.send().await?.json::<T>().await?
         };
 
         trace!("Received daemon RPC response: {:?}", rsp);
@@ -224,7 +214,7 @@ impl RpcClient {
             inner: CallerWrapper(Arc::new(RemoteCaller {
                 http_client: reqwest::ClientBuilder::new().build().unwrap(),
                 addr,
-                rpc_auth: RpcAuthentication::None
+                rpc_auth: RpcAuthentication::None,
             })),
         }
     }
@@ -234,7 +224,7 @@ impl RpcClient {
             inner: CallerWrapper(Arc::new(RemoteCaller {
                 http_client: reqwest::ClientBuilder::new().build().unwrap(),
                 addr,
-                rpc_auth
+                rpc_auth,
             })),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,11 +132,13 @@ impl RemoteCaller {
             .json(&method_call);
 
         let rsp = if let Credentials{username, password} = &self.rpc_auth {
-            req.send_with_digest_auth(username, password).await?
+            req.send_with_digest_auth(username, password)
+                .await?
                 .json::<response::Output>()
                 .await?
         } else{
-            req.send().await?
+            req.send()
+                .await?
                 .json::<response::Output>()
                 .await?
         };
@@ -161,13 +163,21 @@ impl RemoteCaller {
             json_params
         );
 
-        let rsp = client
+        let req = client
             .post(uri)
-            .json(&json_params)
-            .send()
-            .await?
-            .json::<T>()
-            .await?;
+            .json(&json_params);
+
+        let rsp = if let Credentials{username, password} = &self.rpc_auth {
+            req.send_with_digest_auth(username, password)
+                .await?
+                .json::<T>()
+                .await?
+        } else{
+            req.send()
+                .await?
+                .json::<T>()
+                .await?
+        };
 
         trace!("Received daemon RPC response: {:?}", rsp);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,9 @@ use std::{
 use tracing::*;
 use uuid::Uuid;
 
+#[cfg(feature = "rpc_authentication")]
 use crate::RpcAuthentication::Credentials;
+#[cfg(feature = "rpc_authentication")]
 use diqwest::WithDigestAuth;
 
 enum RpcParams {
@@ -106,6 +108,7 @@ impl From<RpcParams> for Params {
 struct RemoteCaller {
     http_client: reqwest::Client,
     addr: String,
+    #[allow(dead_code)]
     rpc_auth: RpcAuthentication,
 }
 
@@ -129,6 +132,10 @@ impl RemoteCaller {
 
         let req = client.post(&uri).json(&method_call);
 
+        #[cfg(not(feature = "rpc_authentication"))]
+        let rsp = req.send().await?.json::<response::Output>().await?;
+
+        #[cfg(feature = "rpc_authentication")]
         let rsp = if let Credentials { username, password } = &self.rpc_auth {
             req.send_with_digest_auth(username, password)
                 .await?
@@ -160,6 +167,10 @@ impl RemoteCaller {
 
         let req = client.post(uri).json(&json_params);
 
+        #[cfg(not(feature = "rpc_authentication"))]
+        let rsp = req.send().await?.json::<T>().await?;
+
+        #[cfg(feature = "rpc_authentication")]
         let rsp = if let Credentials { username, password } = &self.rpc_auth {
             req.send_with_digest_auth(username, password)
                 .await?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,9 +61,18 @@ use std::{
 use tracing::*;
 use uuid::Uuid;
 
+use diqwest::WithDigestAuth;
+use crate::RpcAuthentication::Credentials;
+
 enum RpcParams {
     Array(Box<dyn Iterator<Item = Value> + Send + 'static>),
     Map(Box<dyn Iterator<Item = (String, Value)> + Send + 'static>),
+    None,
+}
+
+#[derive(Clone, Debug)]
+pub enum RpcAuthentication {
+    Credentials{username: String, password: String},
     None,
 }
 
@@ -97,6 +106,7 @@ impl From<RpcParams> for Params {
 struct RemoteCaller {
     http_client: reqwest::Client,
     addr: String,
+    rpc_auth: RpcAuthentication
 }
 
 impl RemoteCaller {
@@ -117,13 +127,19 @@ impl RemoteCaller {
 
         trace!("Sending JSON-RPC method call: {:?}", method_call);
 
-        let rsp = client
+        let req = client
             .post(&uri)
-            .json(&method_call)
-            .send()
-            .await?
-            .json::<response::Output>()
-            .await?;
+            .json(&method_call);
+
+        let rsp = if let Credentials{username, password} = &self.rpc_auth {
+            req.send_with_digest_auth(username, password).await?
+                .json::<response::Output>()
+                .await?
+        } else{
+            req.send().await?
+                .json::<response::Output>()
+                .await?
+        };
 
         trace!("Received JSON-RPC response: {:?}", rsp);
         let v = jsonrpc_core::Result::<Value>::from(rsp);
@@ -198,6 +214,17 @@ impl RpcClient {
             inner: CallerWrapper(Arc::new(RemoteCaller {
                 http_client: reqwest::ClientBuilder::new().build().unwrap(),
                 addr,
+                rpc_auth: RpcAuthentication::None
+            })),
+        }
+    }
+
+    pub fn with_authentication(addr: String, rpc_auth: RpcAuthentication) -> Self {
+        Self {
+            inner: CallerWrapper(Arc::new(RemoteCaller {
+                http_client: reqwest::ClientBuilder::new().build().unwrap(),
+                addr,
+                rpc_auth
             })),
         }
     }

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   monerod:
-    image: ghcr.io/farcaster-project/containers/monerod:${MONERO_VERSION:-0.18.1.2}
+    image: ghcr.io/farcaster-project/containers/monerod:${MONERO_VERSION:-0.18.0.0}
     environment:
       NETWORK: regtest
       MONEROD_RPC_PORT: 18081
@@ -12,7 +12,7 @@ services:
       - 18081:18081
 
   monero-wallet-rpc:
-    image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:${MONERO_VERSION:-0.18.1.2}
+    image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:${MONERO_VERSION:-0.18.0.0}
     environment:
       MONERO_DAEMON_ADDRESS: monerod:18081
       MONERO_DAEMON_HOST: monerod:18081
@@ -23,7 +23,7 @@ services:
       - 18083:18083
 
   monerod-rpc-authentication:
-    image: ghcr.io/farcaster-project/containers/monerod:${MONERO_VERSION:-0.18.1.2}
+    image: ghcr.io/farcaster-project/containers/monerod:${MONERO_VERSION:-0.18.0.0}
     depends_on:
       - "monerod"
     ports:
@@ -39,7 +39,7 @@ services:
               --fixed-difficulty 1
 
   monero-wallet-rpc-authentication:
-    image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:${MONERO_VERSION:-0.18.1.2}
+    image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:${MONERO_VERSION:-0.18.0.0}
     depends_on:
       - "monerod"
     ports:

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -18,3 +18,18 @@ services:
       - "monerod"
     ports:
       - 18083:18083
+
+  monero-wallet-rpc-authentication:
+    image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.18.0.0
+    depends_on:
+      - "monerod"
+    ports:
+      - 18084:18084
+    command: >
+      monero-wallet-rpc --rpc-login foo:bar 
+                        --wallet-dir wallets 
+                        --daemon-address monerod:18081 
+                        --rpc-bind-ip 0.0.0.0 
+                        --rpc-bind-port 18084
+                        --confirm-external-bind 
+                        --trusted-daemon

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -19,6 +19,22 @@ services:
     ports:
       - 18083:18083
 
+  monerod-rpc-authentication:
+    image: ghcr.io/farcaster-project/containers/monerod:0.18.0.0
+    depends_on:
+      - "monerod"
+    ports:
+      - 18085:18081
+    command: >
+      monerod --regtest
+              --rpc-bind-ip 0.0.0.0
+              --rpc-bind-port 18081
+              --rpc-login foo:bar
+              --confirm-external-bind
+              --non-interactive
+              --offline
+              --fixed-difficulty 1
+
   monero-wallet-rpc-authentication:
     image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.18.0.0
     depends_on:

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,18 +1,21 @@
 version: "3.7"
 services:
   monerod:
-    image: ghcr.io/farcaster-project/containers/monerod:0.18.0.0
+    image: ghcr.io/farcaster-project/containers/monerod:${MONERO_VERSION:-0.18.1.2}
     environment:
       NETWORK: regtest
+      MONEROD_RPC_PORT: 18081
+      MONEROD_ZMQ_PORT: 18082
       OFFLINE: --offline
       DIFFICULTY: 1
     ports:
       - 18081:18081
 
   monero-wallet-rpc:
-    image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.18.0.0
+    image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:${MONERO_VERSION:-0.18.1.2}
     environment:
       MONERO_DAEMON_ADDRESS: monerod:18081
+      MONERO_DAEMON_HOST: monerod:18081
       WALLET_RPC_PORT: 18083
     depends_on:
       - "monerod"
@@ -20,7 +23,7 @@ services:
       - 18083:18083
 
   monerod-rpc-authentication:
-    image: ghcr.io/farcaster-project/containers/monerod:0.18.0.0
+    image: ghcr.io/farcaster-project/containers/monerod:${MONERO_VERSION:-0.18.1.2}
     depends_on:
       - "monerod"
     ports:
@@ -36,7 +39,7 @@ services:
               --fixed-difficulty 1
 
   monero-wallet-rpc-authentication:
-    image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.18.0.0
+    image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:${MONERO_VERSION:-0.18.1.2}
     depends_on:
       - "monerod"
     ports:

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::env;
 use monero::Hash;
 use monero_rpc::{RpcAuthentication, RpcClient};
+use std::env;
 
 mod clients_tests;
 
@@ -63,16 +63,14 @@ async fn main_functional_test() {
     clients_tests::all_clients_interaction::run().await;
 }
 
-
 fn setup_rpc_auth_client(username: &str, password: &str, port: u32) -> RpcClient {
     let whost = env::var("MONERO_WALLET_HOST_1").unwrap_or_else(|_| "localhost".into());
     let rpc_credentials = RpcAuthentication::Credentials {
         username: username.into(),
-        password: password.into()
+        password: password.into(),
     };
-    let rpc_client = RpcClient::with_authentication(
-        format!("http://{}:{}", whost, port),
-        rpc_credentials);
+    let rpc_client =
+        RpcClient::with_authentication(format!("http://{}:{}", whost, port), rpc_credentials);
 
     rpc_client
 }
@@ -97,7 +95,9 @@ async fn test_daemon_rpc_auth_fail() {
 async fn test_daemon_rpc_rpc_auth() {
     let rpc_client = setup_rpc_auth_client("foo", "bar", 18085).daemon_rpc();
     let transactions = vec![Hash::from_low_u64_be(1)];
-    let daemon_transactions = rpc_client.get_transactions(transactions, Some(true), Some(true)).await;
+    let daemon_transactions = rpc_client
+        .get_transactions(transactions, Some(true), Some(true))
+        .await;
 
     assert!(daemon_transactions.is_ok());
 }

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 use std::env;
-use monero_rpc::{RpcAuthentication, RpcClient, WalletClient};
+use monero::Hash;
+use monero_rpc::{RpcAuthentication, RpcClient};
 
 mod clients_tests;
 
@@ -63,22 +64,47 @@ async fn main_functional_test() {
 }
 
 
-fn setup_rpc_auth_client(username: &str, password: &str) -> WalletClient {
+fn setup_rpc_auth_client(username: &str, password: &str, port: u32) -> RpcClient {
     let whost = env::var("MONERO_WALLET_HOST_1").unwrap_or_else(|_| "localhost".into());
     let rpc_credentials = RpcAuthentication::Credentials {
         username: username.into(),
         password: password.into()
     };
     let rpc_client = RpcClient::with_authentication(
-        format!("http://{}:18084", whost),
-        rpc_credentials).wallet();
+        format!("http://{}:{}", whost, port),
+        rpc_credentials);
 
     rpc_client
 }
 
 #[tokio::test]
+async fn test_daemon_rpc_auth() {
+    let rpc_client = setup_rpc_auth_client("foo", "bar", 18085).daemon();
+    let daemon_transactions = rpc_client.get_block_count().await;
+
+    assert!(daemon_transactions.is_ok());
+}
+
+#[tokio::test]
+async fn test_daemon_rpc_auth_fail() {
+    let rpc_client = setup_rpc_auth_client("invalid", "bar", 18085).daemon();
+    let daemon_transactions = rpc_client.get_block_count().await;
+
+    assert!(daemon_transactions.is_err());
+}
+
+#[tokio::test]
+async fn test_daemon_rpc_rpc_auth() {
+    let rpc_client = setup_rpc_auth_client("foo", "bar", 18085).daemon_rpc();
+    let transactions = vec![Hash::from_low_u64_be(1)];
+    let daemon_transactions = rpc_client.get_transactions(transactions, Some(true), Some(true)).await;
+
+    assert!(daemon_transactions.is_ok());
+}
+
+#[tokio::test]
 async fn test_rpc_auth() {
-    let rpc_client = setup_rpc_auth_client("foo", "bar");
+    let rpc_client = setup_rpc_auth_client("foo", "bar", 18084).wallet();
     assert!(rpc_client.get_version().await.is_ok());
 
     let version = rpc_client.get_version().await.unwrap();
@@ -87,7 +113,7 @@ async fn test_rpc_auth() {
 
 #[tokio::test]
 async fn test_rpc_auth_fail() {
-    let rpc_client = setup_rpc_auth_client("invalid", "auth");
+    let rpc_client = setup_rpc_auth_client("invalid", "auth", 18084).wallet();
 
     assert!(rpc_client.get_version().await.is_err());
 }

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -63,6 +63,7 @@ async fn main_functional_test() {
     clients_tests::all_clients_interaction::run().await;
 }
 
+#[cfg(feature = "rpc_authentication")]
 fn setup_rpc_auth_client(username: &str, password: &str, port: u32) -> RpcClient {
     let whost = env::var("MONERO_WALLET_HOST_1").unwrap_or_else(|_| "localhost".into());
     let rpc_credentials = RpcAuthentication::Credentials {
@@ -76,6 +77,7 @@ fn setup_rpc_auth_client(username: &str, password: &str, port: u32) -> RpcClient
 }
 
 #[tokio::test]
+#[cfg(feature = "rpc_authentication")]
 async fn test_daemon_rpc_auth() {
     let rpc_client = setup_rpc_auth_client("foo", "bar", 18085).daemon();
     let daemon_transactions = rpc_client.get_block_count().await;
@@ -84,6 +86,7 @@ async fn test_daemon_rpc_auth() {
 }
 
 #[tokio::test]
+#[cfg(feature = "rpc_authentication")]
 async fn test_daemon_rpc_auth_fail() {
     let rpc_client = setup_rpc_auth_client("invalid", "bar", 18085).daemon();
     let daemon_transactions = rpc_client.get_block_count().await;
@@ -92,6 +95,7 @@ async fn test_daemon_rpc_auth_fail() {
 }
 
 #[tokio::test]
+#[cfg(feature = "rpc_authentication")]
 async fn test_daemon_rpc_rpc_auth() {
     let rpc_client = setup_rpc_auth_client("foo", "bar", 18085).daemon_rpc();
     let transactions = vec![Hash::from_low_u64_be(1)];
@@ -103,6 +107,7 @@ async fn test_daemon_rpc_rpc_auth() {
 }
 
 #[tokio::test]
+#[cfg(feature = "rpc_authentication")]
 async fn test_rpc_auth() {
     let rpc_client = setup_rpc_auth_client("foo", "bar", 18084).wallet();
     assert!(rpc_client.get_version().await.is_ok());
@@ -112,6 +117,7 @@ async fn test_rpc_auth() {
 }
 
 #[tokio::test]
+#[cfg(feature = "rpc_authentication")]
 async fn test_rpc_auth_fail() {
     let rpc_client = setup_rpc_auth_client("invalid", "auth", 18084).wallet();
 


### PR DESCRIPTION
This PR implements #43 for both monerod rpc and wallet rpc 

Docker containers with --rpc-login enabled have been added for both monerod and monero-wallet-rpc, tests are included as well.

Currently I added a new constructor RpcClient::with_authentication() but seeing that both #77 and #81 are using the current RpcClient::new() in a backwards incompatible way I also made a branch with a new RpcClient builder called RpcClientBuilder which would allow for backwards compatibility and enable all three new features to be used together.

This is can be seen at https://github.com/monero-ecosystem/monero-rpc-rs/compare/master...refactor-ring:rpc-client-builder-merged?expand=1

UPDATE
Had to change the github actions setup a bit to make the tests pass with the new containers, instead of redefining the containers in the github actions config it now spins up the containers through docker-compose up using the existing docker-compose.yml