### PR TITLE
ci: add workflow to publish releases on crates.io

### DIFF
--- a/.github/workflows/release-to-crates-io.yml
+++ b/.github/workflows/release-to-crates-io.yml
@@ -1,0 +1,14 @@
+name: Release to crates.io
+
+# In case a release is created manually, publish the release on crates.io
+on:
+  release:
+    types: [created]
+
+jobs:
+  release_to_crates:
+    name: Publish the new release to crates.io
+    uses: monero-rs/workflows/.github/workflows/release-to-crates-io.yml@v2.0.1
+    secrets:
+      cratesio_token: ${{ secrets.H4SH3D_CARGO_REGISTRY_TOKEN }}
+


### PR DESCRIPTION
We can know auto-publish on crates.io