### PR TITLE
fix: rollback monero v0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Rollback Monero library bump from `0.18` to `0.17`
+
 ## [0.3.0] - 2022-12-12
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ fixed-hash = "0.8"
 hex = "0.4"
 http = "0.2"
 jsonrpc-core = "18"
-monero = { version = "0.18", features = ["serde"] }
+monero = { version = "0.17", features = ["serde"] }
 reqwest = { version = "0.11", features = ["json", "socks"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
Move to next major Monero release in version `0.4.0`