### PR TITLE
Complete release to crates workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -10,3 +10,11 @@ jobs:
     name: Create from merged release branch
     if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
     uses: monero-rs/workflows/.github/workflows/create-release.yml@v2.0.2
+
+  release_to_crates:
+    name: Publish the new release to crates.io
+    uses: monero-rs/workflows/.github/workflows/release-to-crates-io.yml@v2.0.2
+    # Do not run before creating the release is done
+    needs: create_release
+    secrets:
+      cratesio_token: ${{ secrets.H4SH3D_CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release-to-crates-io.yml
+++ b/.github/workflows/release-to-crates-io.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release_to_crates:
     name: Publish the new release to crates.io
-    uses: monero-rs/workflows/.github/workflows/release-to-crates-io.yml@v2.0.1
+    uses: monero-rs/workflows/.github/workflows/release-to-crates-io.yml@v2.0.2
     secrets:
       cratesio_token: ${{ secrets.H4SH3D_CARGO_REGISTRY_TOKEN }}
 


### PR DESCRIPTION
Add the missing job when creating release based on PR merges and bump to latest version the shared workflow.