### PR TITLE
Fix: reintroduced wrongly reverted #87

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Disable chrono default features by @silverpill ([#87](https://github.com/monero-rs/monero-rpc-rs/pull/87))
+
 ## [0.3.1] - 2022-12-12
 
 ### Changed
@@ -25,10 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Monero library bumped to version `0.18` ([#83](https://github.com/monero-rs/monero-rpc-rs/pull/83))
 - Update fixed-hash requirement from 0.7 to 0.8 ([#85](https://github.com/monero-rs/monero-rpc-rs/pull/85))
-
-### Removed
-
-- Disable chrono default features by @silverpill ([#87](https://github.com/monero-rs/monero-rpc-rs/pull/87))
 
 ## [0.2.0] - 2022-07-29
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ description = "RPC client for Monero daemon and wallet"
 
 [dependencies]
 anyhow = "1"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde"] }
 diqwest = { version = "1.1", optional = true }
 fixed-hash = "0.8"
 hex = "0.4"


### PR DESCRIPTION
#87 got accidentally reverted in #92. This PR cherry picks the commit dc5940aa3fb9041eba5d30c7b1aa4cd8a950eed3 from #87 and update the changelog for the `0.3.2` release.