### PR TITLE
chore: fix ci badge url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://img.shields.io/github/workflow/status/monero-rs/monero-rpc-rs/Build)](https://github.com/monero-rs/monero-rpc-rs/blob/master/.github/workflows/build.yml)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/monero-rs/monero-rpc-rs/build.yml?branch=main)](https://github.com/monero-rs/monero-rpc-rs/blob/master/.github/workflows/build.yml)
 [![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
 [![Crates.io](https://img.shields.io/crates/v/monero-rpc.svg)](https://crates.io/crates/monero-rpc)
 [![Documentation](https://docs.rs/monero-rpc/badge.svg)](https://docs.rs/monero-rpc)


### PR DESCRIPTION
New shields.io URL for displaying CI status badge.