### PR TITLE
Added support for the "get_attribute" and "set_attribute" methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1327,6 +1327,35 @@ impl WalletClient {
 
         Ok((u16::try_from(major)?, u16::try_from(minor)?))
     }
+
+    /// Returns an attribute as a string or an error when there is no attribute for the given key
+    pub async fn get_attribute(&self, key: String) -> anyhow::Result<String> {
+        let params = empty().chain(once(("key", key.into())));
+
+        #[derive(Deserialize)]
+        struct Rsp {
+            value: String,
+        }
+
+        Ok(self
+            .inner
+            .request::<Rsp>("get_attribute", RpcParams::map(params))
+            .await?
+            .value)
+    }
+
+    /// Set an arbitrary attribute which is saved in the wallet
+    pub async fn set_attribute(&self, key: String, value: String) -> anyhow::Result<()> {
+        let params = empty()
+            .chain(once(("key", key.into())))
+            .chain(once(("value", value.into())));
+
+        self.inner
+            .request::<IgnoredAny>("set_attribute", RpcParams::map(params))
+            .await?;
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/tests/clients_tests/basic_wallet.rs
+++ b/tests/clients_tests/basic_wallet.rs
@@ -297,5 +297,21 @@ pub async fn run() {
 
     helpers::wallet::sign_and_verify_assert_ok(&wallet, "test message").await;
 
+    helpers::wallet::get_attribute_error(&wallet, "nonexistingattribute".to_string()).await;
+
+    helpers::wallet::set_attribute_assert_ok(
+        &wallet,
+        "attribute_key".to_string(),
+        "attribute_value".to_string(),
+    )
+    .await;
+
+    helpers::wallet::get_attribute_assert_ok(
+        &wallet,
+        "attribute_key".to_string(),
+        "attribute_value".to_string(),
+    )
+    .await;
+
     helpers::wallet::close_wallet_assert_ok(&wallet).await;
 }

--- a/tests/clients_tests/helpers/wallet.rs
+++ b/tests/clients_tests/helpers/wallet.rs
@@ -741,3 +741,17 @@ pub async fn sign_and_verify_assert_ok(wallet: &WalletClient, message: &str) {
         .unwrap();
     assert!(signature_ok);
 }
+
+pub async fn get_attribute_error(wallet: &WalletClient, key: String) {
+    let err = wallet.get_attribute(key).await.unwrap_err();
+    assert_eq!(err.to_string(), "Server error: Attribute not found.");
+}
+
+pub async fn get_attribute_assert_ok(wallet: &WalletClient, key: String, expected_value: String) {
+    let value_from_wallet = wallet.get_attribute(key).await.unwrap();
+    assert_eq!(value_from_wallet, expected_value);
+}
+
+pub async fn set_attribute_assert_ok(wallet: &WalletClient, key: String, value: String) {
+    wallet.set_attribute(key, value).await.unwrap()
+}


### PR DESCRIPTION
Implemented the methods for storing and retrieving wallet attributes:

https://www.getmonero.org/resources/developer-guides/wallet-rpc.html#set_attribute
https://www.getmonero.org/resources/developer-guides/wallet-rpc.html#get_attribute