### PR TITLE
Added support for the create_wallet rpc method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1356,6 +1356,16 @@ impl WalletClient {
 
         Ok(())
     }
+
+    /// Create a new account
+    pub async fn create_account(&self, label: Option<String>) -> anyhow::Result<CreateWallet>{
+        let params = empty()
+            .chain(once(("label", label.into())));
+        Ok(self
+            .inner
+            .request::<CreateWallet>("create_account", RpcParams::map(params))
+            .await?)
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1361,10 +1361,10 @@ impl WalletClient {
     pub async fn create_account(&self, label: Option<String>) -> anyhow::Result<CreateWallet>{
         let params = empty()
             .chain(once(("label", label.into())));
-        Ok(self
-            .inner
-            .request::<CreateWallet>("create_account", RpcParams::map(params))
-            .await?)
+        self
+        .inner
+        .request::<CreateWallet>("create_account", RpcParams::map(params))
+        .await
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1358,13 +1358,11 @@ impl WalletClient {
     }
 
     /// Create a new account
-    pub async fn create_account(&self, label: Option<String>) -> anyhow::Result<CreateWallet>{
-        let params = empty()
-            .chain(once(("label", label.into())));
-        self
-        .inner
-        .request::<CreateWallet>("create_account", RpcParams::map(params))
-        .await
+    pub async fn create_account(&self, label: Option<String>) -> anyhow::Result<CreateWallet> {
+        let params = empty().chain(once(("label", label.into())));
+        self.inner
+            .request::<CreateWallet>("create_account", RpcParams::map(params))
+            .await
     }
 }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -559,6 +559,16 @@ pub struct KeyImageImportResponse {
     pub unspent: Amount,
 }
 
+/// Return type of wallet `create_wallet`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CreateWallet {
+    /// Index of the new account.
+    pub account_index: u32,
+    /// Generated wallet address.
+    pub address: Address,
+
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/models.rs
+++ b/src/models.rs
@@ -566,7 +566,6 @@ pub struct CreateWallet {
     pub account_index: u32,
     /// Generated wallet address.
     pub address: Address,
-
 }
 
 #[cfg(test)]

--- a/tests/clients_tests/basic_wallet.rs
+++ b/tests/clients_tests/basic_wallet.rs
@@ -313,5 +313,6 @@ pub async fn run() {
     )
     .await;
 
+    helpers::wallet::create_account_assert_ok(&wallet, Some(String::from("test"))).await;
     helpers::wallet::close_wallet_assert_ok(&wallet).await;
 }

--- a/tests/clients_tests/helpers/wallet.rs
+++ b/tests/clients_tests/helpers/wallet.rs
@@ -756,7 +756,7 @@ pub async fn set_attribute_assert_ok(wallet: &WalletClient, key: String, value: 
     wallet.set_attribute(key, value).await.unwrap()
 }
 
-pub async fn create_account_assert_ok(wallet: &WalletClient, label: Option<String>){
+pub async fn create_account_assert_ok(wallet: &WalletClient, label: Option<String>) {
     let res = wallet.create_account(label).await;
     assert!(res.is_ok());
     assert!(res.unwrap().account_index >= 1);

--- a/tests/clients_tests/helpers/wallet.rs
+++ b/tests/clients_tests/helpers/wallet.rs
@@ -755,3 +755,9 @@ pub async fn get_attribute_assert_ok(wallet: &WalletClient, key: String, expecte
 pub async fn set_attribute_assert_ok(wallet: &WalletClient, key: String, value: String) {
     wallet.set_attribute(key, value).await.unwrap()
 }
+
+pub async fn create_account_assert_ok(wallet: &WalletClient, label: Option<String>){
+    let res = wallet.create_account(label).await;
+    assert!(res.is_ok());
+    assert!(res.unwrap().account_index >= 1);
+}


### PR DESCRIPTION
The test I added only checks if the account_index is >=1 since before the implementation of the create_wallet method all wallets were limited to using addresses with account_index = 0. I'm new to the monero ecosystem and its inner working so if there's anything you see that is wrong feel free to change it or message me and I'll do the edit.