### PR TITLE
Fix WalletClient::get_transfers with Out=true in Category Selector

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -516,7 +516,7 @@ pub struct GotTransfer {
     /// JSON object containing the major & minor subaddress index.
     pub subaddr_index: subaddress::Index,
     /// Estimation of the confirmations needed for the transaction to be included in a block.
-    pub suggested_confirmations_threshold: u64,
+    pub suggested_confirmations_threshold: Option<u64>,
     /// POSIX timestamp for when this transfer was first confirmed in a block (or timestamp submission if not mined yet).
     #[serde(with = "chrono::serde::ts_seconds")]
     pub timestamp: DateTime<Utc>,

--- a/tests/clients_tests/all_clients_interaction.rs
+++ b/tests/clients_tests/all_clients_interaction.rs
@@ -445,7 +445,7 @@ pub async fn run() {
         note: "".to_string(),
         payment_id: HashString(PaymentId::zero()),
         subaddr_index: Index { major: 0, minor: 0 },
-        suggested_confirmations_threshold: 1,
+        suggested_confirmations_threshold: Some(1),
         // this is any date, since it will not be tested against anything
         timestamp: DateTime::from_naive_utc_and_offset(
             NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),


### PR DESCRIPTION
Currently calling get_transfers fails with Out=true in the category_selector:
called `Result::unwrap()` on an `Err` value: missing field `suggested_confirmations_threshold`

This change makes `GotTransfer::suggested_confirmations_threshold: Option<u64>`, instead of just `u64`, fixing the issue