### PR TITLE
Add destinations field to GotTransfer, Fix `WalletClient::get_transfers()` where `Out=true`

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -492,6 +492,13 @@ impl<'de> Deserialize<'de> for TransferHeight {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
+pub struct Destination{
+    pub address: Address,
+    #[serde(with = "amount::serde::as_pico")]
+    pub amount: Amount,
+}
+
 /// Return type of wallet `get_transfer` and `get_transfers`.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
 pub struct GotTransfer {
@@ -510,13 +517,15 @@ pub struct GotTransfer {
     /// Height of the first block that confirmed this transfer (0 if not mined yet).
     pub height: TransferHeight,
     /// Note about this transfer.
-    pub note: String,
+    pub note: String, 
+    /// Destinations for this transfer
+    pub destinations: Option<Vec<Destination>>,
     /// Payment ID for this transfer.
     pub payment_id: HashString<PaymentId>,
     /// JSON object containing the major & minor subaddress index.
     pub subaddr_index: subaddress::Index,
     /// Estimation of the confirmations needed for the transaction to be included in a block.
-    pub suggested_confirmations_threshold: u64,
+    pub suggested_confirmations_threshold: Option<u64>,
     /// POSIX timestamp for when this transfer was first confirmed in a block (or timestamp submission if not mined yet).
     #[serde(with = "chrono::serde::ts_seconds")]
     pub timestamp: DateTime<Utc>,

--- a/tests/clients_tests/all_clients_interaction.rs
+++ b/tests/clients_tests/all_clients_interaction.rs
@@ -8,10 +8,10 @@ use monero::{
     Address, Amount, Hash, KeyPair, Network, ViewPair,
 };
 use monero_rpc::{
-    BalanceData, BlockHeightFilter, GetTransfersCategory, GetTransfersSelector, GotTransfer,
-    HashString, IncomingTransfer, IncomingTransfers, KeyImageImportResponse, Payment,
-    PrivateKeyType, SubaddressBalanceData, SweepAllArgs, Transaction, TransactionsResponse,
-    TransferHeight, TransferOptions, TransferPriority, TransferType,
+    BalanceData, BlockHeightFilter, Destination, GetTransfersCategory, GetTransfersSelector, 
+    GotTransfer, HashString, IncomingTransfer, IncomingTransfers, KeyImageImportResponse,
+    Payment, PrivateKeyType, SubaddressBalanceData, SweepAllArgs, Transaction,
+    TransactionsResponse, TransferHeight, TransferOptions, TransferPriority, TransferType
 };
 
 use super::helpers;
@@ -445,7 +445,7 @@ pub async fn run() {
         note: "".to_string(),
         payment_id: HashString(PaymentId::zero()),
         subaddr_index: Index { major: 0, minor: 0 },
-        suggested_confirmations_threshold: 1,
+        suggested_confirmations_threshold: Some(1),
         // this is any date, since it will not be tested against anything
         timestamp: DateTime::from_naive_utc_and_offset(
             NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
@@ -454,6 +454,9 @@ pub async fn run() {
         txid: HashString(transfer_1_data.tx_hash.0.as_ref().to_vec()),
         transfer_type: GetTransfersCategory::Pending,
         unlock_time: 0,
+        destinations: Some(vec![Destination{ 
+            address: Address::from_bytes("77NksNmbDDMXYDecHKQr11j5xvk47csdnDDNn5qWz5BeSaQQ9iJukKKFaCycbeM5oa77MwJTJyehweKaFFpf1Lmc3UXZ4ac".as_bytes()).unwrap(), 
+            amount: Amount::from_pico(30000000000) }]),
     });
     helpers::wallet::get_transfer_assert_got_transfer(
         &wallet,


### PR DESCRIPTION
- added `struct Destination`
this was not present despite wallet RPC server
sending the destinations
- added `GotTransfer::destinations: Option<Vec<Destination>>` 
- changed `GotTransfer::suggested_confirmations_threshold: Option<u64>`
    this allows `Out=true` in the `category_selector` to not panic